### PR TITLE
feature: Initial strategy boilerplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,18 @@ Online portfolio selection is a fundamental problem in computational finance whi
 ## Project Timeline & Build Night Agendas
 
 Available [here](timeline/README.md).
+
+## Development Instructions
+
+1. Clone the repository.
+2. Create and activate a virtual environment in the project root named `env`. See [the official Python tutorial](https://docs.python.org/3/tutorial/venv.html) for more information in setting up virtual environments.
+3. Install all required packages by using `pip install -r requirements.txt`.
+4. Begin development.
+
+### Testing
+
+To run tests: `python -m pytest`
+
+To write tests:
+
+- Create a new file in `tests/` and follow standard Pytest conventions to write tests.

--- a/olps/datasources/datasource.py
+++ b/olps/datasources/datasource.py
@@ -1,0 +1,33 @@
+from typing import *
+
+import numpy as np
+
+
+class DataSource:
+    # A matrix of price relative vectors.
+    # Each column is a PRV, and the time increases from left to right.
+    price_relatives: np.array
+
+    # A matrix of prices.
+    # Each column is a price, and the time increases from left to right.
+    # Note that this matrix will have one extra column.
+    prices: np.array
+
+    def __init__(self, initial_prices: np.array):
+        """
+        Initialize the data source with the price of all assets at the beginning of strategy execution.
+        """
+        self.prices = initial_prices
+        self.price_relatives = None
+
+    def add_prices(self, prices: np.array) -> None:
+        """
+        Update the data source with new prices. This should only be done right before executing the
+        strategy's update() method, as this will use the new prices to calculate PRVs. 
+        """
+        self.prices = np.column_stack((self.prices, prices))
+        prv = self.prices[:, -1] / self.prices[:, -2]
+        if self.price_relatives is not None:
+            self.price_relatives = np.column_stack((self.price_relatives, prv))
+        else:
+            self.price_relatives = prv

--- a/olps/strategies/strategy.py
+++ b/olps/strategies/strategy.py
@@ -1,0 +1,79 @@
+from abc import ABC, abstractmethod
+from typing import *
+
+import numpy as np
+from olps.datasources.datasource import DataSource
+
+
+class Strategy(ABC):
+    """
+    Abstract class allowing for implementation of almost any type of online porfolio selection
+    strategy.
+    Key method to override in child implementations includes the private update_weights method.
+    If the strategy requires specially-computed data for each portfolio computation, perform
+    and store this data manipulation in a DataSource subclass.
+    """
+
+    # Array of weights for each asset in the portfolio.
+    weights: np.array
+    # Cumulative wealth at every time step the strategy is run.
+    cumulative_wealth: np.array
+
+    def __init__(self, num_assets: int) -> None:
+        """
+        Initialize the strategy based on the number of assets.
+        Note that the weights are set to 1 / num_assets as specified in the paper.
+        """
+        self.weights = np.ones((num_assets, )) / num_assets
+        self.cumulative_wealth = np.ones((1,))
+
+    @abstractmethod
+    def update_weights(self, market_data: DataSource) -> None:
+        """
+        Abstract private method to update weights.
+        Should be overridden in client strategy classes.
+        """
+        pass
+
+    def update_wealth(self, current_return: float) -> float:
+        """
+        Private method to compute strategy's cumulative return.
+        Stores in cumulative wealth and returns the current cumulative return value.
+        """
+        cumulative_return = self.cumulative_wealth[-1] * current_return
+        self.cumulative_wealth = np.column_stack(
+            (self.cumulative_wealth, cumulative_return)
+        )
+        return cumulative_return
+
+    def get_return(self, price_relatives: np.array) -> float:
+        """
+        Get the return from the previous trading period based on the price relatives provided.
+        """
+        ret: np.float64 = np.dot(self.weights, price_relatives)
+        if not isinstance(ret, np.float64):
+            raise ValueError('Price relative is not of expected shape')
+        return float(ret)
+
+    @final
+    def update(self, market_data: DataSource) -> float:
+        """
+        Standard final method to update weights based on a data source and update wealth so far.
+        """
+        if market_data.price_relatives is None:
+            raise ValueError(
+                'Data source does not have price relative vector to update on.')
+        # Get last price relative
+        last_price_relative = None
+        if len(market_data.price_relatives.shape) == 1:
+            # If the price relative is still a 1D array, we only have 1 price relative
+            last_price_relative = market_data.price_relatives
+        else:
+            # Otherwise, get the last price relative in the PRV history matrix
+            last_price_relative = market_data.price_relatives[:, -1]
+        # Calculate period return b_t * x_t
+        period_return = self.get_return(last_price_relative)
+        # Calculate cumulative return: S_{t-1} * (current period return)
+        cumulative_return = self.update_wealth(period_return)
+        self.update_weights(market_data)
+        return cumulative_return

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,13 @@
+attrs==20.3.0
+iniconfig==1.1.1
+numpy==1.20.1
+packaging==20.9
+pandas==1.2.3
+pluggy==0.13.1
+py==1.10.0
+pyparsing==2.4.7
+pytest==6.2.2
+python-dateutil==2.8.1
+pytz==2021.1
+six==1.15.0
+toml==0.10.2

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,7 @@
+from setuptools import setup, find_packages
+
+setup(
+    name="olps",
+    version="0.0.0",
+    packages=find_packages()
+)

--- a/tests/test_datasource.py
+++ b/tests/test_datasource.py
@@ -1,0 +1,45 @@
+import pytest
+from typing import *
+from olps.datasources.datasource import DataSource
+import numpy as np
+
+
+class TestDatasource:
+
+    @pytest.fixture
+    def basic_datasource(self) -> Dict[str, Union[np.array, DataSource]]:
+        """
+        Create a basic pytest fixture that will just initialize a data source for testing purposes.
+        """
+        initial_prices = np.array([137.18, 1827.36, 262.01]).T
+        return {
+            'initial_prices': initial_prices,
+            'next_prices': np.array([136.76, 1893.07, 267.08]).T,
+            'ds': DataSource(initial_prices=initial_prices)
+        }
+
+    def test_price_storage(self, basic_datasource: DataSource) -> None:
+        """
+        Ensure the price is stored correctly.
+        """
+        assert basic_datasource['ds'].prices.shape == basic_datasource['initial_prices'].shape
+
+    def test_price_addition(self, basic_datasource: DataSource) -> None:
+        """
+        Ensure single price addition works as expected, adding it to the prices matrix and computing
+        the appropriate price relatives.
+        """
+        basic_datasource['ds'].add_prices(basic_datasource['next_prices'])
+        assert basic_datasource['ds'].prices.shape == (3, 2)
+        assert basic_datasource['ds'].price_relatives is not None
+        assert basic_datasource['ds'].price_relatives.shape == (3, )
+
+    def test_multiple_price_addition(self, basic_datasource: DataSource) -> None:
+        """
+        Ensure multiple price addition works as expected.
+        """
+        basic_datasource['ds'].add_prices(basic_datasource['next_prices'])
+        basic_datasource['ds'].add_prices(basic_datasource['next_prices'])
+        assert basic_datasource['ds'].prices.shape == (3, 3)
+        assert basic_datasource['ds'].price_relatives is not None
+        assert basic_datasource['ds'].price_relatives.shape == (3, 2)

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -1,0 +1,54 @@
+import pytest
+from math import isclose
+from typing import *
+from olps.strategies.strategy import Strategy
+from olps.datasources.datasource import DataSource
+import numpy as np
+
+
+class TestStrategy:
+
+    @pytest.fixture
+    def fake_strategy(self) -> Strategy:
+        """
+        Create a basic pytest fixture that will just provide a barebones implementation of Strategy.
+        """
+        class FakeStrategy(Strategy):
+            def update_weights(self, market_data: DataSource) -> None:
+                return
+
+        return FakeStrategy(num_assets=3)
+
+    @pytest.fixture
+    def fake_datasource(self) -> Dict[str, Union[np.array, DataSource]]:
+        """
+        Create a basic pytest fixture that will just initialize a data source for testing purposes.
+        """
+        initial_prices = np.array([137.18, 1827.36, 262.01]).T
+        return {
+            'initial_prices': initial_prices,
+            'next_prices': np.array([136.76, 1893.07, 267.08]).T,
+            'ds': DataSource(initial_prices=initial_prices)
+        }
+
+    def test_constructor(self, fake_strategy: Strategy) -> None:
+        """
+        Check that the constructor initializes the strategy object as expected.
+        """
+        strat = fake_strategy
+        assert strat.weights.shape == (3, )
+        assert strat.cumulative_wealth.shape == (1, )
+        assert np.array_equal(strat.weights, np.array([1/3, 1/3, 1/3]).T)
+
+    def test_update_with_price_relatives(self, fake_strategy: Strategy, fake_datasource: Dict[str, Union[np.array, DataSource]]) -> None:
+        """
+        Check that update() works as expected in updating weights, period, and cumulative return.
+        """
+        strat = fake_strategy
+        ds = fake_datasource['ds']
+        ds.add_prices(fake_datasource['next_prices'])
+        cumulative_return = strat.update(ds)
+        assert np.array_equal(strat.weights, np.array([1/3, 1/3, 1/3]).T)
+        assert isclose(cumulative_return, 1.017415905)
+        assert strat.cumulative_wealth.shape == (1, 2)
+        assert strat.weights.shape == (3, )


### PR DESCRIPTION
Adds the following:
- A basic Python package setup with Virtualenv-based dependency management
- Base classes for implementing strategies and computing necessary data such as price relative vectors as needed.
- Test suite for the base classes
- Instructions for setup on any platform

Please read the files changed in this PR so you have a better idea of how to implement strategies moving forward. I would also like feedback on the current structure!