### PR TITLE
hotfix: Handle overlapping ticks

### DIFF
--- a/olps/market/mdp.py
+++ b/olps/market/mdp.py
@@ -30,12 +30,27 @@ class MarketDataProvider:
     def __calc_min_fill_time(self) -> int:
         max_time = None
         for stock in self.assets:
+            # index = (self.data['ticker'].values == stock).argmin()
             index = self.data[self.data['ticker'] == stock].index[0]
             if max_time is None:
                 max_time = index
             else:
                 max_time = max(max_time, index)
         return max_time
+
+    def get_min_fill_idx(self) -> int:
+        loc = self.data.index.get_loc(self.min_fill_time)
+        if isinstance(loc, slice):
+            return int(loc.stop - 1)
+        elif isinstance(loc, int) or isinstance(loc, np.int64):
+            return int(loc)
+        else:
+            raise ValueError(
+                'Got unexpected value from get_loc on data index'
+            )
+
+    def get_time(self, time: int) -> pd.DataFrame:
+        return self.data.loc[[time]]
 
     def min_time(self) -> int:
         return self.data.index.min()


### PR DESCRIPTION
- Add minimum fill index logic and get_time method
- Handle case of overlapping ticks in TradingMarket
